### PR TITLE
Change the database structure with new system of memberships

### DIFF
--- a/app/Models/Membresia.php
+++ b/app/Models/Membresia.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Membresia extends Model
 {
-    //
+    public function tipo()
+    {
+        return $this->belongsTo(TipoMembresia::class, 'id_tipo_membresia');
+    }
 }

--- a/app/Models/TipoMembresia.php
+++ b/app/Models/TipoMembresia.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TipoMembresia extends Model
+{
+    protected $table = 'tipos_membresia';
+    protected $fillable = ['nombre', 'clases_adquiridas'];
+
+    public function membresias()
+    {
+        return $this->hasMany(Membresia::class, 'id_tipo_membresia');
+    }
+}

--- a/database/migrations/2025_04_31_000003_create_tipos_membresia_table.php
+++ b/database/migrations/2025_04_31_000003_create_tipos_membresia_table.php
@@ -11,13 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('pagos', function (Blueprint $table) {
+        Schema::create('tipos_membresia', function (Blueprint $table) {
             $table->id();
-            $table->unsignedBigInteger('id_usuario');
-            $table->unsignedBigInteger('id_membresia')->nullable();
-            $table->unsignedBigInteger('id_clase')->nullable();
-            $table->decimal('monto');
-            $table->date('fecha');
+            $table->string('nombre');
+            $table->integer('clases_adquiridas');
             $table->timestamps();
         });
     }
@@ -27,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('pagos');
+        Schema::dropIfExists('tipos_membresia');
     }
 };

--- a/database/migrations/2025_05_24_015533_create_membresias_table.php
+++ b/database/migrations/2025_05_24_015533_create_membresias_table.php
@@ -14,12 +14,13 @@ return new class extends Migration
         Schema::create('membresias', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('id_usuario');
-            $table->integer('clases_adquiridas');
-            $table->integer('clases_disponibles');
-            $table->integer('clases_ocupadas');
+            $table->unsignedBigInteger('id_tipo_membresia');
+            $table->integer('clases_disponibles')->default(0);
+            $table->integer('clases_ocupadas')->default(0);
             $table->timestamps();
 
-            $table->foreign('id_usuario')->references('id')->on('users');
+            $table->foreign('id_usuario')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('id_tipo_membresia')->references('id')->on('tipos_membresia')->onDelete('cascade');
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
 
         $this->call([
             UsersTableSeeder::class,
+            TipoMembresiaSeeder::class,
             MembresiasTableSeeder::class,
             ClasesTableSeeder::class,
             AsistenciasTableSeeder::class,

--- a/database/seeders/MembresiasTableSeeder.php
+++ b/database/seeders/MembresiasTableSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\User;
 use App\Models\Membresia;
+use App\Models\TipoMembresia;
 
 class MembresiasTableSeeder extends Seeder
 {
@@ -14,14 +15,17 @@ class MembresiasTableSeeder extends Seeder
      */
     public function run(): void
     {
-        $usuarios = User::inRandomOrder()->take(10)->wherenot('rol', 'Admin')->get();
+        $tipos = TipoMembresia::all();
+        $usuarios = User::where('rol', 'Cliente')->get();
 
         foreach ($usuarios as $usuario) {
+            $tipo = $tipos->random();
+
             Membresia::create([
                 'id_usuario' => $usuario->id,
-                'clases_adquiridas' => 20,
-                'clases_disponibles' => rand(5, 15),
-                'clases_ocupadas' => rand(5, 15)
+                'id_tipo_membresia' => $tipo->id,
+                'clases_disponibles' => $tipo->clases_adquiridas,
+                'clases_ocupadas' => 0,
             ]);
         }
     }

--- a/database/seeders/TipoMembresiaSeeder.php
+++ b/database/seeders/TipoMembresiaSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\TipoMembresia;
+
+class TipoMembresiaSeeder extends Seeder
+{
+    public function run()
+    {
+        TipoMembresia::insert([
+            ['nombre' => 'Básica', 'clases_adquiridas' => 5],
+            ['nombre' => 'Estándar', 'clases_adquiridas' => 10],
+            ['nombre' => 'Premium', 'clases_adquiridas' => 20],
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `TipoMembresia` model to manage membership types and refactors the `Membresia` model and related database schema to integrate this new structure. It includes updates to models, migrations, and seeders to support the changes.

### Model and Relationship Updates:
- Added a `TipoMembresia` model with attributes `nombre` and `clases_adquiridas`, and defined a one-to-many relationship with `Membresia` (`app/Models/TipoMembresia.php`).
- Updated the `Membresia` model to include a `tipo` relationship that links to the `TipoMembresia` model (`app/Models/Membresia.php`).

### Database Schema Changes:
- Created a migration for the `tipos_membresia` table with columns `nombre` and `clases_adquiridas` (`database/migrations/2025_04_31_000003_create_tipos_membresia_table.php`).
- Updated the `membresias` table to replace individual class-related columns with a foreign key to `tipos_membresia` and added default values for `clases_disponibles` and `clases_ocupadas` (`database/migrations/2025_05_24_015533_create_membresias_table.php`).
- Modified the `pagos` table to allow `id_membresia` and `id_clase` to be nullable (`database/migrations/2025_05_24_021555_create_pagos_table.php`).

### Seeder Updates:
- Added a `TipoMembresiaSeeder` to populate the `tipos_membresia` table with predefined membership types (`database/seeders/TipoMembresiaSeeder.php`).
- Updated the `MembresiasTableSeeder` to assign a random membership type to each user and set `clases_disponibles` based on the selected type (`database/seeders/MembresiasTableSeeder.php`).
- Registered the `TipoMembresiaSeeder` in the `DatabaseSeeder` class (`database/seeders/DatabaseSeeder.php`).