### PR TITLE
New CRUD for memberships

### DIFF
--- a/app/Http/Controllers/TipoMembresiaController.php
+++ b/app/Http/Controllers/TipoMembresiaController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+use App\Models\TipoMembresia;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+use Illuminate\Http\Request;
+
+class TipoMembresiaController extends Controller
+{
+    public function index(){
+        Log::channel('info')->info('Usuario accedió a la sección de tipos de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol
+        ]);
+
+        $tipoMembresia = new TipoMembresia();
+
+        return view("tipos_membresias.nueva", compact('tipoMembresia'));
+    }
+
+    public function create(){
+        Log::channel('info')->info('Usuario accedió a la creación de un nuevo tipo de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol
+        ]);
+
+        return view("tipos_membresias.nueva", compact('tipoMembresia'));
+    }
+
+    public function list(){
+        Log::channel('info')->info('Usuario accedió a la lista de tipos de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol
+        ]);
+
+        $tiposMembresia = TipoMembresia::all();
+
+        return view("tipos_membresias.lista", compact('tiposMembresia'));
+    }
+
+    public function store(Request $request)
+    {
+        Log::channel('info')->info('Usuario guardó un tipo de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol,
+        ]);
+
+        if ($request->id == null) {
+            $tipoMembresia = new TipoMembresia();
+        } else {
+            $tipoMembresia = TipoMembresia::find($request->id);
+            if (!$tipoMembresia) {
+                return redirect()->back()->withErrors('Tipo de membresía no encontrado.');
+            }
+        }
+
+        $tipoMembresia->nombre = $request->nombre;
+        $tipoMembresia->precio = $request->precio;
+        $tipoMembresia->clases_adquiridas = $request->clases_adquiridas ;
+
+        $tipoMembresia->save();
+        return redirect()->route('tipos_membresias');
+    }
+
+    public function edit($id){
+        Log::channel('info')->info('Usuario accedió a la edición de un tipo de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol,
+            'tipo_membresia_id' => $id
+        ]);
+        $tipoMembresia = TipoMembresia::find($id);
+        $roles = ['Cliente','Instructor','Admin'];
+
+        return view("tipos_membresias.nueva", compact('tipoMembresia', 'roles'));
+    }
+
+    public function destroy($id){
+        Log::channel('warning')->warning('Usuario eliminó un tipo de membresía', [
+            'user_id' => Auth::id(),
+            'rol' => Auth::user()->rol,
+            'tipo_membresia_id' => $id
+        ]);
+
+        $tipoMembresia = TipoMembresia::find($id);
+        $tipoMembresia->delete();
+        return redirect()->to('tipos_membresias');
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -316,12 +316,22 @@ return [
             'icon' => 'fa fa-id-card',
             'submenu' => [
                 [
-                    'text' => 'Lista',
+                    'text' => 'Lista de membresias',
+                    'route' => 'tipos_membresias',
+                    'can' => 'admin',
+                ],
+                [
+                    'text' => 'Nuevo tipo de membresia',
+                    'route' => 'tipo_membresia.nueva', // 👈 Este debe coincidir con el definido en Route::name()
+                    'can' => 'admin',
+                ],
+                [
+                    'text' => 'Membresias de usuarios',
                     'route' => 'membresias',
                     'can' => 'admin',
                 ],
                 [
-                    'text' => 'Nueva',
+                    'text' => 'Asignar membresia',
                     'route' => 'membresia.nueva',
                     'can' => 'admin',
                 ],

--- a/database/migrations/2025_04_31_000003_create_tipos_membresia_table.php
+++ b/database/migrations/2025_04_31_000003_create_tipos_membresia_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
         Schema::create('tipos_membresia', function (Blueprint $table) {
             $table->id();
             $table->string('nombre');
+            $table->decimal('precio', 8, 2);
             $table->integer('clases_adquiridas');
             $table->timestamps();
         });

--- a/database/seeders/TipoMembresiaSeeder.php
+++ b/database/seeders/TipoMembresiaSeeder.php
@@ -11,9 +11,9 @@ class TipoMembresiaSeeder extends Seeder
     public function run()
     {
         TipoMembresia::insert([
-            ['nombre' => 'Básica', 'clases_adquiridas' => 5],
-            ['nombre' => 'Estándar', 'clases_adquiridas' => 10],
-            ['nombre' => 'Premium', 'clases_adquiridas' => 20],
+            ['nombre' => 'Básica', 'clases_adquiridas' => 5, 'precio' => 19.99],
+            ['nombre' => 'Estándar', 'clases_adquiridas' => 10, 'precio' => 29.99],
+            ['nombre' => 'Premium', 'clases_adquiridas' => 20, 'precio' => 39.99],
         ]);
     }
 }

--- a/resources/views/tipos_membresias/lista.blade.php
+++ b/resources/views/tipos_membresias/lista.blade.php
@@ -1,0 +1,55 @@
+@extends('adminlte::page')
+
+@section('title', 'Usuarios')
+
+@section('content_header')
+    <h1>Membresias</h1>
+@stop
+
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card card-primary">
+                <div class="card-header">
+                    <h3 class="card-title">Lista de Usuarios</h3>
+                </div>
+                <div class="card-body">
+                    <table class="table table-bordered table-striped dataTable dtr-inline">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Nombre</th>
+                                <th>Precio</th>
+                                <th>Clases Adquiridas</th>
+                                <th>Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($tiposMembresia as $tipoMembresia)
+                            <tr>
+                                <td>{{$tipoMembresia->id}}</td>
+                                <td>{{$tipoMembresia->nombre}}</td>
+                                <td>{{$tipoMembresia->precio}}</td>
+                                <td>{{$tipoMembresia->clases_adquiridas}}</td>
+                                <td>
+                                    <a href="{{route('tipo_membresia.editar', $tipoMembresia->id)}}" class="btn btn-warning btn-sm">Editar</a>
+                                    <form action="{{route('tipo_membresia.eliminar', $tipoMembresia->id)}}" method="POST">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger btn-sm">Eliminar</button>
+                                    </form>
+                                </td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+@stop
+
+@section('css')
+    {{-- Add here extra stylesheets --}}
+    {{-- <link rel="stylesheet" href="/css/admin_custom.css"> --}}
+@stop
+
+@section('js')
+    <script> console.log("Hi, I'm using the Laravel-AdminLTE package!"); </script>
+@stop

--- a/resources/views/tipos_membresias/nueva.blade.php
+++ b/resources/views/tipos_membresias/nueva.blade.php
@@ -1,0 +1,49 @@
+@extends('adminlte::page')
+
+@section('title', 'Nueva Membresía')
+
+@section('content_header')
+    <h1>Nueva Membresía</h1>
+@stop
+
+@section('content')
+    <div class="row">
+        <div class="col-md-10  offset-md-1">
+            <div class="card card-success">
+                <div class="card-header">
+                    <h3 class="card-title">Crear nueva Membresía</h3>
+                </div>
+                <form action="{{route('tipo_membresia.guardar')}}" method="POST">
+                    <input type="hidden" name="id" value="{{ $tipoMembresia->id}}">
+                    @csrf
+                    <div class="card-body">
+                        <div class="form-group">
+                            <label for="nombre">Nombre</label>
+                            <input type="text" class="form-control" name="nombre" id="nombre" value="{{$tipoMembresia->nombre}}"
+                                placeholder="Ingrese nombre de la nueva membresía">
+                            <label for="precio">Precio</label>
+                            <input type="number" class="form-control" name="precio" id="precio" value="{{$tipoMembresia->precio}}"
+                                placeholder="Ingrese precio de la nueva membresía">
+                            <label for="clases_adquiridas">Clases adquiridas</label>
+                            <input type="number" class="form-control" name="clases_adquiridas" id="clases_adquiridas" value="{{$tipoMembresia->clases_adquiridas}}"
+                                placeholder="Ingrese clases adquiridas de la nueva membresía">
+                        </div>
+                    </div>
+                    <div class="card-footer">
+                        <button type="submit" class="btn btn-success">Crear</button>
+                        <a href="" class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@stop                            
+
+@section('css')
+    {{-- Add here extra stylesheets --}}
+    {{-- <link rel="stylesheet" href="/css/admin_custom.css"> --}}
+@stop
+
+@section('js')
+    <script> console.log("Hi, I'm using the Laravel-AdminLTE package!"); </script>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\MembresiaController;
 use App\Http\Controllers\UsuarioController;
 use App\Http\Controllers\ClaseController;
+use App\Http\Controllers\TipoMembresiaController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
 use Opcodes\LogViewer\Facades\LogViewer;
@@ -67,4 +68,20 @@ Route::get('clase/editar/{id}', [ClaseController::class, 'edit'])
     ->middleware('auth', 'rol:Admin');
 Route::delete('clase/eliminar/{id}', [ClaseController::class, 'destroy'])
     ->name('clase.eliminar')
+    ->middleware('auth', 'rol:Admin');
+
+Route::get('tipos_membresias', [TipoMembresiaController::class, 'list'])
+    ->name('tipos_membresias')
+    ->middleware('auth', 'rol:Admin');
+Route::get('tipo_membresia/nueva', [TipoMembresiaController::class, 'index'])
+    ->name('tipo_membresia.nueva')
+    ->middleware('auth', 'rol:Admin');
+Route::post('tipo_membresia/guardar', [TipoMembresiaController::class, 'store'])
+    ->name('tipo_membresia.guardar')
+    ->middleware('auth', 'rol:Admin');
+Route::get('tipo_membresia/editar/{id}', [TipoMembresiaController::class, 'edit'])
+    ->name('tipo_membresia.editar')
+    ->middleware('auth', 'rol:Admin');
+Route::delete('tipo_membresia/eliminar/{id}', [TipoMembresiaController::class, 'destroy'])
+    ->name('tipo_membresia.eliminar')
     ->middleware('auth', 'rol:Admin');


### PR DESCRIPTION
This pull request introduces a new feature for managing membership types (`TipoMembresia`) in the application. It includes the addition of a controller, database migration and seeder updates, new routes, and views for listing, creating, editing, and deleting membership types. Below are the most important changes grouped by theme:

### Backend Logic for Membership Types
* Added `TipoMembresiaController` with methods for listing, creating, editing, storing, and deleting membership types. Each method logs user actions for auditing purposes (`app/Http/Controllers/TipoMembresiaController.php`).

### Database Changes
* Updated the `tipos_membresia` table to include a `precio` column for membership pricing (`database/migrations/2025_04_31_000003_create_tipos_membresia_table.php`).
* Modified the `TipoMembresiaSeeder` to populate the `precio` field for predefined membership types (`database/seeders/TipoMembresiaSeeder.php`).

### Routes and Navigation
* Added routes for listing, creating, editing, storing, and deleting membership types, protected by authentication and admin role checks (`routes/web.php`). [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR72-R87) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR6)
* Updated the `adminlte.php` configuration to include new menu items for managing membership types (`config/adminlte.php`).

### Frontend Views
* Created a new Blade view for listing membership types, displaying their details, and providing actions for editing and deleting (`resources/views/tipos_membresias/lista.blade.php`).
* Added a Blade view for creating and editing membership types, with a form to input `nombre`, `precio`, and `clases_adquiridas` (`resources/views/tipos_membresias/nueva.blade.php`).